### PR TITLE
Check if the current state address equals input value before updating address state

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: [
-    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-env', { targets: '> 3%, not dead' }],
     '@babel/preset-typescript',
     '@babel/preset-react',
   ],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "types": "yarn tsc",
     "start": "rimraf dist && webpack --mode production --watch",
-    "build": "rimraf dist && webpack --mode development",
+    "build": "rimraf dist && webpack --mode production",
     "build-storybook": "build-storybook --docs",
     "storybook": "start-storybook -p 9009 --docs",
     "lint:check": "eslint './src/**/*.{js,jsx,ts,tsx}'",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "types": "yarn tsc",
     "start": "rimraf dist && webpack --mode production --watch",
-    "build": "rimraf dist && webpack --mode production",
+    "build": "rimraf dist && webpack --mode development",
     "build-storybook": "build-storybook --docs",
     "storybook": "start-storybook -p 9009 --docs",
     "lint:check": "eslint './src/**/*.{js,jsx,ts,tsx}'",

--- a/src/inputs/AddressInput/index.tsx
+++ b/src/inputs/AddressInput/index.tsx
@@ -36,25 +36,25 @@ type AddressInputProps = {
 } & TextFieldInputProps;
 
 function AddressInput({
-                        name,
-                        address,
-                        networkPrefix,
-                        showNetworkPrefix = true,
-                        disabled,
-                        onChangeAddress,
-                        getAddressFromDomain,
-                        customENSThrottleDelay,
-                        showLoadingSpinner,
-                        InputProps,
-                        inputProps,
-                        hiddenLabel = false,
-                        ...rest
-                      }: AddressInputProps): ReactElement {
+  name,
+  address,
+  networkPrefix,
+  showNetworkPrefix = true,
+  disabled,
+  onChangeAddress,
+  getAddressFromDomain,
+  customENSThrottleDelay,
+  showLoadingSpinner,
+  InputProps,
+  inputProps,
+  hiddenLabel = false,
+  ...rest
+}: AddressInputProps): ReactElement {
   const [isLoadingENSResolution, setIsLoadingENSResolution] = useState(false);
   const defaultInputValue = addPrefix(
     address,
     networkPrefix,
-    showNetworkPrefix,
+    showNetworkPrefix
   );
   const inputRef = useRef({ value: defaultInputValue });
   const throttle = useThrottle();
@@ -67,11 +67,11 @@ function AddressInput({
         inputRef.current.value = addPrefix(
           checksumAddress,
           networkPrefix,
-          showNetworkPrefix,
+          showNetworkPrefix
         );
       }
     },
-    [networkPrefix, showNetworkPrefix],
+    [networkPrefix, showNetworkPrefix]
   );
 
   const resolveDomainName = useCallback(async () => {
@@ -123,20 +123,23 @@ function AddressInput({
   }, [address, updateInputValue]);
 
   // we trim, checksum & remove valid network prefix when a valid address is typed by the user
-  const updateAddressState = (value: string) => {
-    const inputValue = trimSpaces(value);
+  const updateAddressState = useCallback(
+    (value) => {
+      const inputValue = trimSpaces(value);
 
-    const inputPrefix = getNetworkPrefix(inputValue);
-    const inputWithoutPrefix = getAddressWithoutNetworkPrefix(inputValue);
+      const inputPrefix = getNetworkPrefix(inputValue);
+      const inputWithoutPrefix = getAddressWithoutNetworkPrefix(inputValue);
 
-    // if the valid network prefix is present, we remove it from the address state
-    const isValidPrefix = networkPrefix === inputPrefix;
-    const checksumAddress = checksumValidAddress(
-      isValidPrefix ? inputWithoutPrefix : inputValue,
-    );
+      // if the valid network prefix is present, we remove it from the address state
+      const isValidPrefix = networkPrefix === inputPrefix;
+      const checksumAddress = checksumValidAddress(
+        isValidPrefix ? inputWithoutPrefix : inputValue
+      );
 
-    onChangeAddress(checksumAddress);
-  };
+      onChangeAddress(checksumAddress);
+    },
+    [networkPrefix, onChangeAddress]
+  );
 
   // when user switch the network we update the address state
   useEffect(() => {
@@ -146,7 +149,7 @@ function AddressInput({
     if (inputValue !== address) {
       updateAddressState(inputRef.current?.value);
     }
-  }, [networkPrefix, address]);
+  }, [networkPrefix, address, updateAddressState]);
 
   // when user types we update the address state
   function onChange(e: ChangeEvent<HTMLInputElement>) {
@@ -194,8 +197,8 @@ export default AddressInput;
 
 function LoaderSpinnerAdornment() {
   return (
-    <InputAdornment position='end'>
-      <CircularProgress size='16px' />
+    <InputAdornment position="end">
+      <CircularProgress size="16px" />
     </InputAdornment>
   );
 }
@@ -213,7 +216,7 @@ function checksumValidAddress(address: string) {
 function addPrefix(
   address: string,
   networkPrefix: string | undefined,
-  showNetworkPrefix = false,
+  showNetworkPrefix = false
 ): string {
   if (!address) {
     return '';

--- a/src/inputs/AddressInput/index.tsx
+++ b/src/inputs/AddressInput/index.tsx
@@ -36,25 +36,25 @@ type AddressInputProps = {
 } & TextFieldInputProps;
 
 function AddressInput({
-  name,
-  address,
-  networkPrefix,
-  showNetworkPrefix = true,
-  disabled,
-  onChangeAddress,
-  getAddressFromDomain,
-  customENSThrottleDelay,
-  showLoadingSpinner,
-  InputProps,
-  inputProps,
-  hiddenLabel = false,
-  ...rest
-}: AddressInputProps): ReactElement {
+                        name,
+                        address,
+                        networkPrefix,
+                        showNetworkPrefix = true,
+                        disabled,
+                        onChangeAddress,
+                        getAddressFromDomain,
+                        customENSThrottleDelay,
+                        showLoadingSpinner,
+                        InputProps,
+                        inputProps,
+                        hiddenLabel = false,
+                        ...rest
+                      }: AddressInputProps): ReactElement {
   const [isLoadingENSResolution, setIsLoadingENSResolution] = useState(false);
   const defaultInputValue = addPrefix(
     address,
     networkPrefix,
-    showNetworkPrefix
+    showNetworkPrefix,
   );
   const inputRef = useRef({ value: defaultInputValue });
   const throttle = useThrottle();
@@ -67,11 +67,11 @@ function AddressInput({
         inputRef.current.value = addPrefix(
           checksumAddress,
           networkPrefix,
-          showNetworkPrefix
+          showNetworkPrefix,
         );
       }
     },
-    [networkPrefix, showNetworkPrefix]
+    [networkPrefix, showNetworkPrefix],
   );
 
   const resolveDomainName = useCallback(async () => {
@@ -123,23 +123,20 @@ function AddressInput({
   }, [address, updateInputValue]);
 
   // we trim, checksum & remove valid network prefix when a valid address is typed by the user
-  const updateAddressState = useCallback(
-    (value) => {
-      const inputValue = trimSpaces(value);
+  const updateAddressState = (value: string) => {
+    const inputValue = trimSpaces(value);
 
-      const inputPrefix = getNetworkPrefix(inputValue);
-      const inputWithoutPrefix = getAddressWithoutNetworkPrefix(inputValue);
+    const inputPrefix = getNetworkPrefix(inputValue);
+    const inputWithoutPrefix = getAddressWithoutNetworkPrefix(inputValue);
 
-      // if the valid network prefix is present, we remove it from the address state
-      const isValidPrefix = networkPrefix === inputPrefix;
-      const checksumAddress = checksumValidAddress(
-        isValidPrefix ? inputWithoutPrefix : inputValue
-      );
+    // if the valid network prefix is present, we remove it from the address state
+    const isValidPrefix = networkPrefix === inputPrefix;
+    const checksumAddress = checksumValidAddress(
+      isValidPrefix ? inputWithoutPrefix : inputValue,
+    );
 
-      onChangeAddress(checksumAddress);
-    },
-    [networkPrefix, onChangeAddress]
-  );
+    onChangeAddress(checksumAddress);
+  };
 
   // when user switch the network we update the address state
   useEffect(() => {
@@ -149,7 +146,7 @@ function AddressInput({
     if (inputValue !== address) {
       updateAddressState(inputRef.current?.value);
     }
-  }, [networkPrefix, address, updateAddressState]);
+  }, [networkPrefix, address]);
 
   // when user types we update the address state
   function onChange(e: ChangeEvent<HTMLInputElement>) {
@@ -197,8 +194,8 @@ export default AddressInput;
 
 function LoaderSpinnerAdornment() {
   return (
-    <InputAdornment position="end">
-      <CircularProgress size="16px" />
+    <InputAdornment position='end'>
+      <CircularProgress size='16px' />
     </InputAdornment>
   );
 }
@@ -216,7 +213,7 @@ function checksumValidAddress(address: string) {
 function addPrefix(
   address: string,
   networkPrefix: string | undefined,
-  showNetworkPrefix = false
+  showNetworkPrefix = false,
 ): string {
   if (!address) {
     return '';

--- a/src/inputs/AddressInput/index.tsx
+++ b/src/inputs/AddressInput/index.tsx
@@ -143,7 +143,12 @@ function AddressInput({
 
   // when user switch the network we update the address state
   useEffect(() => {
-    updateAddressState(inputRef.current?.value);
+    // Because the `address` is going to change after we call `updateAddressState`
+    // To avoid calling `updateAddressState` twice, we check the value and the current address
+    const inputValue = inputRef.current?.value;
+    if (inputValue !== address) {
+      updateAddressState(inputRef.current?.value);
+    }
   }, [networkPrefix, address, updateAddressState]);
 
   // when user types we update the address state

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,4 +62,7 @@ module.exports = {
     fs: 'empty',
     child_process: 'empty',
   },
+  optimization: {
+    minimize: false,
+  },
 };


### PR DESCRIPTION
To avoid a mini infinite loop I'm facing in transaction builder I added a check for address/input value equality before firing `updateAddressState`.

The mini infinite loop looks like following:
1. `address` (passed from controlling component) = '', `inputValue` = "ABC" --> `onChangeAddress` is called
2. `address` (passed from controlling component) = 'ABC', `inputValue` = "ABC" --> `updateAddressState` is called because `address` has changed, and it calls `onChangeAddress` again

I also disabled webpack minimizing because this is a developer-facing library and it's way cooler to debug non-minified code