### PR TITLE
fix: link color in tooltips

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-react-components",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Safe UI components",
   "main": "dist/index.min.js",
   "typings": "dist/index.d.ts",

--- a/src/theme/safeTheme.tsx
+++ b/src/theme/safeTheme.tsx
@@ -444,6 +444,19 @@ const createSafeTheme = (mode: PaletteMode): Theme => {
             ...theme.typography.body2,
             color: theme.palette.background.main,
             backgroundColor: theme.palette.text.primary,
+            '& .MuiLink-root': {
+              color: isDarkMode
+                ? theme.palette.background.main
+                : theme.palette.secondary.main,
+              textDecorationColor: isDarkMode
+                ? theme.palette.background.main
+                : theme.palette.secondary.main,
+            },
+            '& .MuiLink-root:hover': {
+              color: isDarkMode
+                ? theme.palette.text.secondary
+                : theme.palette.secondary.light,
+            },
           }),
           arrow: ({ theme }) => ({
             color: theme.palette.text.primary,


### PR DESCRIPTION
When using a link inside of tooltips the theme makes the link unreadable in light-mode.

This PR fixes the colors of links to the correct ones when embedded in a tooltip.

### Screenshot before
![Screenshot 2023-02-09 at 15 38 54](https://user-images.githubusercontent.com/2670790/217843932-dd9a91a2-b568-47ad-84e2-d0a062fea420.png)

### Screenshot after
![Screenshot 2023-02-09 at 15 36 56](https://user-images.githubusercontent.com/2670790/217843948-6be394bc-f9e8-4ba7-926d-41e8e6189898.png)