### PR TITLE
Fix: previous version detection in release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,12 @@ jobs:
       - name: Extract version
         id: version
         run: |
-          OLD_VERSION=$(npm show @gnosis.pm/safe-react-components version)
-          NEW_VERSION=$(node -p 'require("./package.json").version')
+          OLD_VERSION=$(git describe --tags --abbrev=0)
+          NEW_VERSION=v$(node -p 'require("./package.json").version')
           if [ $NEW_VERSION != $OLD_VERSION ]; then
             echo "New version $NEW_VERSION detected"
-            echo "::set-output name=version::v$NEW_VERSION"
-            git log "v$OLD_VERSION"..HEAD --pretty=format:"* %s" > CHANGELOG.md
+            echo "::set-output name=version::$NEW_VERSION"
+            git log "$OLD_VERSION"..HEAD --pretty=format:"* %s" > CHANGELOG.md
           else
             echo "Version $OLD_VERSION hasn't changed, skipping the release"
             exit 1


### PR DESCRIPTION
When generating a changelog, it was taking the previous version from the latest publish package on NPM.
It should take the latest tag instead.