### PR TITLE
prefix is adding while copying address bug resolved

### DIFF
--- a/src/components/EthHashInfo/CopyAddressButton.tsx
+++ b/src/components/EthHashInfo/CopyAddressButton.tsx
@@ -9,11 +9,11 @@ type CopyAddressButtonProps = {
 };
 
 const CopyAddressButton = ({
-  prefix,
-  address,
-  copyPrefix,
+  
+  address
+  
 }: CopyAddressButtonProps): React.ReactElement => {
-  const addressText = copyPrefix && prefix ? `${prefix}:${address}` : address;
+  const addressText = address;
 
   return <CopyButton text={addressText} />;
 };

--- a/src/components/EthHashInfo/index.tsx
+++ b/src/components/EthHashInfo/index.tsx
@@ -93,9 +93,9 @@ const EthHashInfo = ({
 
           {showCopyButton && (
             <CopyAddressButton
-              prefix={prefix}
+              
               address={address}
-              copyPrefix={shouldPrefix && copyPrefix}
+              
             />
           )}
 


### PR DESCRIPTION
Issue: #224 

Hey 👋 team I have removed the prefix and copyPrefix props from the CopyAddressButton Component. 

This should work fine Now.
