### PR TITLE
Fix: "unique key" warnings in Tooltips

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,48 +1,9 @@
+const mainConfig = require('../webpack.config.js');
+
 module.exports = ({ config }) => {
-  config.module.rules.push({
-    test: /\.(ts|js)x?$/,
-    exclude: [/node_modules/],
-    use: {
-      loader: 'ts-loader',
-    },
-  });
+  config.module.rules = mainConfig.module.rules;
 
-  config.module.rules.push({
-    test: /\.css$/i,
-    use: ['style-loader', 'css-loader'],
-  });
-
-  // remove svg from existing rule
-  config.module.rules = config.module.rules.map((rule) => {
-    if (
-      String(rule.test) ===
-      String(
-        /\.(svg|ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani)(\?.*)?$/
-      )
-    ) {
-      return {
-        ...rule,
-        test: /\.(ico|jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|cur|ani)(\?.*)?$/,
-      };
-    }
-
-    return rule;
-  });
-
-  config.module.rules.push({
-    test: /\.(woff(2)?|ttf|eot)(\?v=\d+\.\d+\.\d+)?$/,
-    type: 'asset/resource',
-    generator: {
-      filename: '[name][ext][query]',
-    },
-  });
-
-  config.module.rules.push({
-    test: /\.(png|jpg)$/i,
-    type: 'asset/inline',
-  });
-
-  config.resolve.extensions.push('.ts', '.tsx', 'woff2');
+  config.resolve.extensions.push('.ts', '.tsx', '.svg', 'woff2');
 
   return config;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@safe-global/safe-react-components",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Safe UI components",
   "main": "dist/index.min.js",
   "typings": "dist/index.d.ts",

--- a/src/components/EthHashInfo/CopyButton.tsx
+++ b/src/components/EthHashInfo/CopyButton.tsx
@@ -42,6 +42,7 @@ const CopyButton = ({
       placement="top"
       onMouseLeave={handleMouseLeave}>
       <IconButton
+        key="copy"
         aria-label={initialToolTipText}
         onClick={handleCopy}
         className={className}

--- a/src/components/ExplorerButton/index.tsx
+++ b/src/components/ExplorerButton/index.tsx
@@ -21,6 +21,7 @@ const ExplorerButton = ({
   return (
     <Tooltip title={title} placement="top">
       <IconButton
+        key="explorer"
         href={href}
         target="_blank"
         rel="noopener noreferrer"


### PR DESCRIPTION
In web-core, there's a key warning whenever either the ExplorerButton or the CopyButton is rendered.
The Tooltip component thinks we're passing an array for some reason. I gave its children a key so that it's happy...
I've also simplified the storybook webpack config.